### PR TITLE
Fix static files serving issue on Vercel

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -130,6 +130,12 @@ USE_TZ = True
 
 STATIC_URL = 'static/'
 
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, 'dish/static'),
+]
+
+# STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
     }],
   "routes": [
     {
+      "src": "/static/(.*)",
+      "dest": "/static/$1"
+    },
+    {
       "src": "/(.*)",
       "dest": "main/wsgi.py"
     }


### PR DESCRIPTION
Add configuration for serving static files in Vercel and update Django settings.

* Modify `main/settings.py` to include `STATICFILES_DIRS` setting with the path to `dish/static` directory.

